### PR TITLE
技術スタックの記載形式を他プロジェクトに揃える

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ ECマーケットプレイスのインフラを担当した。
 
 ##### 技術スタック
 
-- Amazon Aurora MySQL
-- Amazon EC2
+- AWS
+   - Aurora MySQL
+   - EC2
 - Terraform
 - Ansible
 - Bash


### PR DESCRIPTION
## 概要

Aurora 移行プロジェクトの技術スタックの記載形式を、他のプロジェクトに揃えた。

AWS のサービスをフラットに並べていたため、他のプロジェクトと同様に AWS の下にぶら下げる形式に統一した。
